### PR TITLE
Publish to MCP registry

### DIFF
--- a/docs/github_mcp_registry/README.md
+++ b/docs/github_mcp_registry/README.md
@@ -2,7 +2,7 @@
 
 To publish Omni-LPR to the [GitHub MCP Registry](https://github.com/mcp), follow these steps:
 
-1. Download the latest version of `mcp-publisher` from [modelcontextprotocol/registry](https://github.com/modelcontextprotocol/registry) and add it to your PATH.
+1. Download the latest version of `mcp-publisher` binary from [modelcontextprotocol/registry](https://github.com/modelcontextprotocol/registry) and add it to your PATH.
 2. Run `mcp-publisher login github` and follow the instructions to authenticate.
 3. Run `mcp-publisher publish`.
 

--- a/docs/github_mcp_registry/server.json
+++ b/docs/github_mcp_registry/server.json
@@ -7,13 +7,13 @@
     "url": "https://github.com/habedi/omni-lpr",
     "source": "github"
   },
-  "version": "0.3.0",
+  "version": "0.3.1",
   "packages": [
     {
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "omni-lpr",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "transport": {
         "type": "streamable-http",
         "url": "http://127.0.0.1:8000/mcp/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "omni-lpr"
-version = "0.3.0"
+version = "0.3.1"
 description = "A multi-interface (REST and MCP) server for automatic license plate recognition"
 readme = "README.md"
 license = { text = "MIT" }
@@ -21,7 +21,7 @@ keywords = [
     "microservice",
     "onnx",
     "cuda",
-    "mcp-name:io.github.habedi/omni-lpr",
+    "mcp-name: io.github.habedi/omni-lpr",
 ]
 
 classifiers = [


### PR DESCRIPTION
Apply a few changes so Omni-LPR could be published to the GitHub MCP registry. See https://github.com/modelcontextprotocol/registry/issues/531